### PR TITLE
move the proxy logic into a provider function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog], and this crate adheres to [Semantic
 Versioning].
 
+## 0.2.0 - 2022-09-06
+
+* Backwards incompatible change: creating the provider is no longer sufficient
+  to create the proxy listener. Instead, you must call the `startproxy`
+  provider function, and use the port returned in the output in the rest of
+  your calls. The returned port will be the port given in the `host_port`
+  argument to the provider constructor, but using the `startproxy` return value
+  will ensure pulumi creates a dependency such that anything using the
+  function's output will have to happen after the proxy is fully initialized.
+
 ## 0.1.3 - 2021-07-06
 
 * Correct version format in package URL.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PORT = 32123
 
 eks_cluster = eks.Cluster(...)
 
-k8s_proxy.Provider(
+rds_proxy_provider = k8s_proxy.Provider(
     "postgresql-proxy",
     kubeconfig=eks_cluster.kubeconfig,
     host_port=PORT,
@@ -32,10 +32,14 @@ k8s_proxy.Provider(
     pod_selector="workload=postgresql",
 )
 
+port = k8s_proxy.startproxy(
+    opts=pulumi.InvokeOptions(provider=rds_proxy_provider),
+)
+
 provider = postgresql.Provider(
     base_name,
     host="localhost",
-    port=PORT,
+    port=port.port,
     connect_timeout=10,
     database="db",
     username="user",

--- a/cmd/pulumi-sdkgen-kubernetes-proxy/main.go
+++ b/cmd/pulumi-sdkgen-kubernetes-proxy/main.go
@@ -63,6 +63,15 @@ func run(version string) error {
 				"hostPort",
 			},
 		},
+		Functions: map[string]schema.FunctionSpec{
+			"k8s_proxy::startproxy": {
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"port": {TypeSpec: schema.TypeSpec{Type: "integer"}},
+					},
+				},
+			},
+		},
 		Language: map[string]json.RawMessage{
 			"python": json.RawMessage("{}"),
 		},


### PR DESCRIPTION
provider configuration doesn't block execution of the dag, so the proxy
is not guaranteed to come up before dependent resources need it, but by
making a function that returns an output, we can force dependent
resources to wait on that output before proceeding

r? @benesch 